### PR TITLE
Use https for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ Thanks to the authors of [markdown-pdf](https://github.com/alanshaw/markdown-pdf
 
 ## License
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Switches the README license link from http:// to https://piecioshka.mit-license.org.